### PR TITLE
v3.1 - Fix manifest issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Advanced OBS commands and tools to use on your Elgato Stream Deck
 
 **Author's website and contact information:** [https://barraider.com](https://barraider.com)
 
-# New in v3.0
+# New in v3.1
 - 🆕 **Stream Deck+ Support** - New `Input Volume` action allows you to control the volume of an OBS Audio Input from the Dials. Pressing the dial will toggle mute.
 
 # New in v2.9

--- a/streamdeck-obstools/manifest.json
+++ b/streamdeck-obstools/manifest.json
@@ -120,72 +120,6 @@
       "UUID": "com.barraider.obstools.imagesettings",
       "PropertyInspectorPath": "PropertyInspector/ImageSettings.html"
     },
-
-    {
-      "Icon": "Images/icon",
-      "Name": "Input Monitor Set",
-      "States": [
-        {
-          "Image": "Images/volumeAction",
-          "TitleAlignment": "middle",
-          "FontSize": "13"
-        }
-      ],
-      "SupportedInMultiActions": true,
-      "DisableCaching": true,
-      "Tooltip": "Set the monitor type of an audio source in OBS",
-      "UUID": "com.barraider.obstools.sourcemonitorsetter",
-      "PropertyInspectorPath": "PropertyInspector/InputAudioMonitor.html"
-    },
-    {
-      "Icon": "Images/icon",
-      "Name": "Input Mute Toggle",
-      "States": [
-        {
-          "Image": "Images/volumeAction",
-          "TitleAlignment": "middle",
-          "FontSize": "13"
-        }
-      ],
-      "SupportedInMultiActions": true,
-      "DisableCaching": true,
-      "Tooltip": "Toggles the mute on an audio source in OBS",
-      "UUID": "com.barraider.obstools.sourcemutetoggle",
-      "PropertyInspectorPath": "PropertyInspector/InputMuteToggle.html"
-    },
-
-    {
-      "Icon": "Images/icon",
-      "Name": "Input Volume Adjust",
-      "States": [
-        {
-          "Image": "Images/volumeAction",
-          "TitleAlignment": "middle",
-          "FontSize": "13"
-        }
-      ],
-      "SupportedInMultiActions": true,
-      "DisableCaching": true,
-      "Tooltip": "Adjusts the volume of a source in OBS",
-      "UUID": "com.barraider.obstools.sourcevolumeadjuster",
-      "PropertyInspectorPath": "PropertyInspector/InputVolumeAdjuster.html"
-    },
-    {
-      "Icon": "Images/icon",
-      "Name": "Input Volume Set",
-      "States": [
-        {
-          "Image": "Images/volumeAction",
-          "TitleAlignment": "middle",
-          "FontSize": "13"
-        }
-      ],
-      "SupportedInMultiActions": true,
-      "DisableCaching": true,
-      "Tooltip": "Set the volume of a source in OBS",
-      "UUID": "com.barraider.obstools.sourcevolumesetter",
-      "PropertyInspectorPath": "PropertyInspector/InputVolumeSet.html"
-    },
     {
       "Icon": "Images/icon",
       "Name": "Input Monitor Set",
@@ -591,7 +525,7 @@
   "Name": "OBS Tools",
   "Icon": "Images/pluginIcon",
   "URL": "https://BarRaider.com/",
-  "Version": "3.0",
+  "Version": "3.1",
   "DefaultWindowSize": [ 620, 750 ],
   "CodePath": "com.barraider.obstools",
   "Category": "OBS Tools [BarRaider]",


### PR DESCRIPTION
- 🆕 **Stream Deck+ Support** - New `Input Volume` action allows you to control the volume of an OBS Audio Input from the Dials. Pressing the dial will toggle mute.
- Improved logging and stability
- Fixed bug in manifest